### PR TITLE
DELETEのDBテストを追加

### DIFF
--- a/src/test/java/com/shima/todo_list/mapper/TodoListMapperTest.java
+++ b/src/test/java/com/shima/todo_list/mapper/TodoListMapperTest.java
@@ -92,6 +92,23 @@ class TodoListMapperTest {
         Todo todo = new Todo(99, "詳細設計", LocalDate.of(2023, 12, 4), null, null);
         todoListMapper.update(todo);
     }
+
+    //DELETE機能のDBテスト
+    @Test
+    @DataSet(value = "datasets/todolists.yml")
+    @ExpectedDataSet(value = "datasets/delete_todolists.yml")
+    @Transactional
+    public void 存在するタスク情報を削除すること() {
+        todoListMapper.delete(3);
+    }
+
+    @Test
+    @DataSet(value = "datasets/todolists.yml")
+    @ExpectedDataSet(value = "datasets/todolists.yml")
+    @Transactional
+    public void 存在しないidのタスク情報を指定した場合は削除されないこと() {
+        todoListMapper.delete(99);
+    }
 }
 
 

--- a/src/test/resources/datasets/delete_todolists.yml
+++ b/src/test/resources/datasets/delete_todolists.yml
@@ -1,0 +1,16 @@
+todo_lists:
+  - id: 1
+    name: "構想"
+    start_date: '2023-12-06'
+    scheduled_end_date: null
+    actual_end_date: null
+  - id: 2
+    name: "API作成"
+    start_date: '2023-12-07'
+    scheduled_end_date: null
+    actual_end_date: null
+  - id: 4
+    name: "リリース"
+    start_date: '2023-12-09'
+    scheduled_end_date: null
+    actual_end_date: null


### PR DESCRIPTION
### 概要

DBテスト(DELETE)実装

### 動作確認
* 指定したidのタスク情報を削除。
* 指定したidが存在しない場合に、例外が発生。