### PR TITLE
ServiceTestにDELETETest

### DIFF
--- a/src/test/java/com/shima/todo_list/service/TodoListServiceTest.java
+++ b/src/test/java/com/shima/todo_list/service/TodoListServiceTest.java
@@ -93,4 +93,25 @@ public class TodoListServiceTest {
                 });
         verify(todoListMapper).findById(99);
     }
+
+    //DELETE機能のテスト
+    @Test
+    public void 指定したIDのデータが削除できること() {
+        doReturn(Optional.of(new Todo(2, "API作成", LocalDate.of(2023, 12, 7), null, null))).when(todoListMapper).findById(2);
+        todoListService.findById(2);
+        verify(todoListMapper).findById(2);
+        verify(todoListMapper).findById(2);
+
+    }
+
+    @Test
+    public void 存在しないIDのデータを削除したときに例外処理が動作こと() {
+        doReturn(Optional.empty()).when(todoListMapper).findById(99);
+
+        assertThatThrownBy(
+                () -> todoListService.findById(99)
+        ).isInstanceOfSatisfying(
+                TaskNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("task not found"));
+        verify(todoListMapper).findById(99);
+    }
 }

--- a/src/test/java/com/shima/todo_list/service/TodoListServiceTest.java
+++ b/src/test/java/com/shima/todo_list/service/TodoListServiceTest.java
@@ -99,9 +99,9 @@ public class TodoListServiceTest {
     @Test
     public void 指定したIDのデータが削除できること() {
         doReturn(Optional.of(new Todo(2, "API作成", LocalDate.of(2023, 12, 7), null, null))).when(todoListMapper).findById(2);
-        todoListService.findById(2);
+        todoListService.delete(2);
         verify(todoListMapper).findById(2);
-        verify(todoListMapper).findById(2);
+        verify(todoListMapper).delete(2);
 
     }
 
@@ -110,9 +110,9 @@ public class TodoListServiceTest {
         doReturn(Optional.empty()).when(todoListMapper).findById(99);
 
         assertThatThrownBy(
-                () -> todoListService.findById(99)
+                () -> todoListService.delete(99)
         ).isInstanceOfSatisfying(
-                TaskNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("task not found"));
+                TaskNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("Task not found"));
         verify(todoListMapper).findById(99);
         verify(todoListMapper, never()).delete(99);
     }

--- a/src/test/java/com/shima/todo_list/service/TodoListServiceTest.java
+++ b/src/test/java/com/shima/todo_list/service/TodoListServiceTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -113,5 +114,6 @@ public class TodoListServiceTest {
         ).isInstanceOfSatisfying(
                 TaskNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("task not found"));
         verify(todoListMapper).findById(99);
+        verify(todoListMapper, never()).delete(99);
     }
 }


### PR DESCRIPTION
### 概要

Service単体テストにてDELETEのテストを実装

### 動作確認
* 指定したid のタスク情報を削除。
* 指定したid が存在しない場合は例外処理が動作する。